### PR TITLE
Fix card editor sheet not showing

### DIFF
--- a/StreetPass/StreetPass_MainView.swift
+++ b/StreetPass/StreetPass_MainView.swift
@@ -22,7 +22,7 @@ struct ShareSheetView: UIViewControllerRepresentable {
 
 // MARK: - Main View
 struct StreetPass_MainView: View {
-    @StateObject private var viewModel: StreetPassViewModel
+    @EnvironmentObject private var viewModel: StreetPassViewModel
     @State private var searchText: String = ""
     private let isForSwiftUIPreview: Bool
 
@@ -66,8 +66,6 @@ struct StreetPass_MainView: View {
 
     init(isForSwiftUIPreview: Bool = false) {
         self.isForSwiftUIPreview = isForSwiftUIPreview
-        let userID = isForSwiftUIPreview ? "previewUser" : "local_user"
-        _viewModel = StateObject(wrappedValue: StreetPassViewModel(userID: userID))
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- use `@EnvironmentObject` for the view model in `StreetPass_MainView`
- remove creation of a new view model instance

This ensures tapping **draw / edit my card** sets `isDrawingSheetPresented` on the same `StreetPassViewModel` instance observed by the `App` scene, letting the drawing sheet appear.

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_68414fc3ae848320bda2fa8b0c1ba287