### PR TITLE
Fix drawing sheet drag issue

### DIFF
--- a/StreetPass/StreetPassApp.swift
+++ b/StreetPass/StreetPassApp.swift
@@ -178,7 +178,7 @@ struct StreetPassApp: App {
             // Use the existing main view (StreetPass_MainView) instead of the nonexistent "_New" variant.
             StreetPass_MainView()
                 .environmentObject(streetPassViewModel)
-                .sheet(isPresented: $streetPassViewModel.isDrawingSheetPresented) {
+                .fullScreenCover(isPresented: $streetPassViewModel.isDrawingSheetPresented) {
                     DrawingEditorSheetView(
                         isPresented: $streetPassViewModel.isDrawingSheetPresented,
                         cardDrawingData: $streetPassViewModel.cardForEditor.drawingData


### PR DESCRIPTION
## Summary
- present DrawingEditorSheetView using `fullScreenCover` so downward strokes don't drag the sheet

## Testing
- `swift test` *(fails: no Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415159c7f083209ccf8308eb9bf779