### PR TITLE
Add shake to reset feature

### DIFF
--- a/StreetPass/DeviceShakeView.swift
+++ b/StreetPass/DeviceShakeView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+extension Notification.Name {
+    static let deviceDidShake = Notification.Name("deviceDidShake")
+}
+
+struct DeviceShakeView: UIViewRepresentable {
+    func makeUIView(context: Context) -> ShakeReportingView {
+        let view = ShakeReportingView()
+        return view
+    }
+
+    func updateUIView(_ uiView: ShakeReportingView, context: Context) {}
+
+    class ShakeReportingView: UIView {
+        override var canBecomeFirstResponder: Bool { true }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            becomeFirstResponder()
+        }
+
+        override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+            super.motionEnded(motion, with: event)
+            if motion == .motionShake {
+                NotificationCenter.default.post(name: .deviceDidShake, object: nil)
+            }
+        }
+    }
+}

--- a/StreetPass/StreetPassViewModel.swift
+++ b/StreetPass/StreetPassViewModel.swift
@@ -160,6 +160,31 @@ class StreetPassViewModel: ObservableObject, StreetPassBLEManagerDelegate {
         showInfoMessage(message)
     }
 
+    // MARK: - Reset & Restart Logic
+    func resetAllData() {
+        logViewModel("Resetting all StreetPass data and generating new user ID.")
+
+        bleManager.stop()
+
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "streetPass_PersistentUserID_v1")
+        defaults.removeObject(forKey: "streetPass_LocalUserCard_v2")
+        defaults.removeObject(forKey: "streetPass_ReceivedCards_v2")
+
+        let newID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        let freshManager = StreetPassBLEManager(userID: newID)
+        freshManager.delegate = self
+        self.bleManager = freshManager
+
+        self.cardForEditor = freshManager.localUserCard
+        self.greetingName = freshManager.localUserCard.displayName.split(separator: " ").first.map(String.init) ?? "user"
+        self.newCardsCountForBanner = 0
+        self.lastErrorMessage = nil
+        self.lastInfoMessage = nil
+
+        bleManager.start()
+    }
+
 
     // MARK: - StreetPassBLEManagerDelegate Conformance
     // SINGLE DEFINITIONS of these delegate methods:

--- a/StreetPass/StreetPass_MainView.swift
+++ b/StreetPass/StreetPass_MainView.swift
@@ -122,6 +122,7 @@ struct StreetPass_MainView: View {
     @State private var showMainContent = false
     @State private var scrollOffset: CGFloat = 0
     @State private var timeBasedGreeting: String = ""
+    @State private var showResetAlert: Bool = false
 
 
     @AppStorage("favorite_user_ids_json_v1") private var _appStorageFavoriteUserIDsJSON: String = "[]"
@@ -226,6 +227,16 @@ struct StreetPass_MainView: View {
         return NavigationStack {
             mainContent(sortedCards: sortedCards)
                 .background(AppTheme.backgroundColor.ignoresSafeArea())
+                .background(DeviceShakeView())
+                .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
+                    showResetAlert = true
+                }
+                .alert("Reset StreetPass?", isPresented: $showResetAlert) {
+                    Button("Cancel", role: .cancel) { }
+                    Button("Reset", role: .destructive) { viewModel.resetAllData() }
+                } message: {
+                    Text("This will erase all data and restart StreetPass.")
+                }
                 .onAppear {
                     timeBasedGreeting = getTimeBasedGreetingLogic() // Refresh on appear
                     withAnimation(.interpolatingSpring(stiffness: 100, damping: 12).delay(0.1)) {


### PR DESCRIPTION
## Summary
- add `DeviceShakeView` to detect shake gestures
- show reset alert when a shake is detected
- implement `resetAllData` in `StreetPassViewModel`

## Testing
- `swiftc StreetPass/StreetPassApp.swift -o /tmp/a.out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68420c3ca8ac8320a27353b9accbb764