### PR TITLE
Fix black screen by async ViewModel load

### DIFF
--- a/StreetPass/StreetPassApp.swift
+++ b/StreetPass/StreetPassApp.swift
@@ -171,20 +171,35 @@ struct StreetPassApp: App {
         }
     }
 
-    @StateObject var streetPassViewModel = StreetPassViewModel(userID: getPersistentAppUserID())
+    @State private var viewModel: StreetPassViewModel? = nil
+
+    private func binding<T>(_ keyPath: ReferenceWritableKeyPath<StreetPassViewModel, T>) -> Binding<T> {
+        Binding(
+            get: { viewModel![keyPath: keyPath] },
+            set: { viewModel?[keyPath: keyPath] = $0 }
+        )
+    }
 
     var body: some Scene {
         WindowGroup {
-            // Use the existing main view (StreetPass_MainView) instead of the nonexistent "_New" variant.
-            StreetPass_MainView()
-                .environmentObject(streetPassViewModel)
-                .fullScreenCover(isPresented: $streetPassViewModel.isDrawingSheetPresented) {
-                    DrawingEditorSheetView(
-                        isPresented: $streetPassViewModel.isDrawingSheetPresented,
-                        cardDrawingData: $streetPassViewModel.cardForEditor.drawingData
-                    )
-                    .interactiveDismissDisabled()
+            Group {
+                if let vm = viewModel {
+                    StreetPass_MainView()
+                        .environmentObject(vm)
+                        .fullScreenCover(isPresented: binding(\.isDrawingSheetPresented)) {
+                            DrawingEditorSheetView(
+                                isPresented: binding(\.isDrawingSheetPresented),
+                                cardDrawingData: binding(\.cardForEditor.drawingData)
+                            )
+                            .interactiveDismissDisabled()
+                        }
+                } else {
+                    ProgressView("Starting StreetPass…")
+                        .task {
+                            self.viewModel = StreetPassViewModel(userID: Self.getPersistentAppUserID())
+                        }
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- revert erroneous Info.plist changes
- load `StreetPassViewModel` asynchronously on launch to avoid an initial blank screen

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430d3533d8832092c4682eff9f136b