### PR TITLE
Fix black screen by delaying BLE manager init

### DIFF
--- a/StreetPass/StreetPassApp.swift
+++ b/StreetPass/StreetPassApp.swift
@@ -171,30 +171,47 @@ struct StreetPassApp: App {
         }
     }
 
-    @StateObject private var viewModel: StreetPassViewModel
-
-    init() {
-        _viewModel = StateObject(wrappedValue: StreetPassViewModel(userID: Self.getPersistentAppUserID()))
-    }
+    @State private var viewModel: StreetPassViewModel? = nil
 
     private func binding<T>(_ keyPath: ReferenceWritableKeyPath<StreetPassViewModel, T>) -> Binding<T> {
         Binding(
-            get: { viewModel[keyPath: keyPath] },
-            set: { newValue in viewModel[keyPath: keyPath] = newValue }
+            get: {
+                guard let vm = viewModel else {
+                    fatalError("StreetPassViewModel not initialized before binding access")
+                }
+                return vm[keyPath: keyPath]
+            },
+            set: { newValue in
+                guard let _ = viewModel else { return }
+                viewModel![keyPath: keyPath] = newValue
+            }
         )
     }
 
     var body: some Scene {
         WindowGroup {
-            StreetPass_MainView()
-                .environmentObject(viewModel)
-                .fullScreenCover(isPresented: binding(\.isDrawingSheetPresented)) {
-                    DrawingEditorSheetView(
-                        isPresented: binding(\.isDrawingSheetPresented),
-                        cardDrawingData: binding(\.cardForEditor.drawingData)
-                    )
-                    .interactiveDismissDisabled()
+            Group {
+                if let vm = viewModel {
+                    StreetPass_MainView()
+                        .environmentObject(vm)
+                        .fullScreenCover(isPresented: binding(\.isDrawingSheetPresented)) {
+                            DrawingEditorSheetView(
+                                isPresented: binding(\.isDrawingSheetPresented),
+                                cardDrawingData: binding(\.cardForEditor.drawingData)
+                            )
+                            .interactiveDismissDisabled()
+                        }
+                } else {
+                    ProgressView("Starting StreetPass…")
+                        .onAppear {
+                            // Defer view model creation until after the first frame
+                            // so Bluetooth prompts aren't blocked on launch
+                            if self.viewModel == nil {
+                                self.viewModel = StreetPassViewModel(userID: Self.getPersistentAppUserID())
+                            }
+                        }
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- revert unused Info.plist changes
- create `StreetPassViewModel` after the first frame so Bluetooth prompts aren't blocked
- ensure progress view uses `onAppear` so it actually dismisses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68435ebe9fdc8320b48aad037e51f215