### PR TITLE
Fix progress screen when no card exists

### DIFF
--- a/StreetPass/StreetPassApp.swift
+++ b/StreetPass/StreetPassApp.swift
@@ -171,19 +171,27 @@ struct StreetPassApp: App {
         }
     }
 
-    @State private var viewModel: StreetPassViewModel? = nil
+    /// Holder class lets us lazily create the actual view model while still
+    /// using `@StateObject` so the reference survives view reloads. Without
+    /// this the progress view could reappear on first launch when the view is
+    /// recreated before the async init finishes.
+    private final class ViewModelHolder: ObservableObject {
+        @Published var viewModel: StreetPassViewModel? = nil
+    }
+
+    @StateObject private var viewModelHolder = ViewModelHolder()
 
     private func binding<T>(_ keyPath: ReferenceWritableKeyPath<StreetPassViewModel, T>) -> Binding<T> {
         Binding(
             get: {
-                guard let vm = viewModel else {
+                guard let vm = viewModelHolder.viewModel else {
                     fatalError("StreetPassViewModel not initialized before binding access")
                 }
                 return vm[keyPath: keyPath]
             },
             set: { newValue in
-                guard let _ = viewModel else { return }
-                viewModel![keyPath: keyPath] = newValue
+                guard let _ = viewModelHolder.viewModel else { return }
+                viewModelHolder.viewModel![keyPath: keyPath] = newValue
             }
         )
     }
@@ -191,7 +199,7 @@ struct StreetPassApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if let vm = viewModel {
+                if let vm = viewModelHolder.viewModel {
                     StreetPass_MainView()
                         .environmentObject(vm)
                         .fullScreenCover(isPresented: binding(\.isDrawingSheetPresented)) {
@@ -206,9 +214,9 @@ struct StreetPassApp: App {
                         .onAppear {
                             // Defer view model creation until after the first frame
                             // so Bluetooth prompts aren't blocked on launch
-                            guard viewModel == nil else { return }
+                            guard viewModelHolder.viewModel == nil else { return }
                             DispatchQueue.main.async {
-                                self.viewModel = StreetPassViewModel(userID: Self.getPersistentAppUserID())
+                                viewModelHolder.viewModel = StreetPassViewModel(userID: Self.getPersistentAppUserID())
                             }
 
                         }


### PR DESCRIPTION
## Summary
- ensure the view model survives SwiftUI view reloads

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68436f2f3d608320b750dc4b1ff02d4c